### PR TITLE
Use ninja in test, detect if the sysroot librt is linked in cmake targets and fix RT linking

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_aarch64_:
         CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -26,7 +26,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cdt_name
-  - docker_image
 zlib:
 - '1.2'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @jcarpent @lesteve @wolfv
-* @traversaro
+* @jcarpent @lesteve @traversaro @wolfv

--- a/README.md
+++ b/README.md
@@ -179,5 +179,6 @@ Feedstock Maintainers
 
 * [@jcarpent](https://github.com/jcarpent/)
 * [@lesteve](https://github.com/lesteve/)
+* [@traversaro](https://github.com/traversaro/)
 * [@wolfv](https://github.com/wolfv/)
 

--- a/recipe/fix_rt_link.patch
+++ b/recipe/fix_rt_link.patch
@@ -1,0 +1,22 @@
+From 88dbfb93194f15d0a894be713b8f9cb2ea7098a8 Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio.traversaro@iit.it>
+Date: Thu, 9 Dec 2021 09:54:34 +0100
+Subject: [PATCH] Link rt with name and not with absolute path
+
+---
+ code/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/code/CMakeLists.txt b/code/CMakeLists.txt
+index e45bf8a2aa..42743fe672 100644
+--- a/code/CMakeLists.txt
++++ b/code/CMakeLists.txt
+@@ -1300,7 +1300,7 @@ ENDIF()
+ 
+ # Add RT-extension library for glTF importer with Open3DGC-compression.
+ IF (RT_FOUND AND ASSIMP_IMPORTER_GLTF_USE_OPEN3DGC)
+-  TARGET_LINK_LIBRARIES(assimp ${RT_LIBRARY})
++  TARGET_LINK_LIBRARIES(assimp rt)
+ ENDIF ()
+ 
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
   requires:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - make  # [not win]
+    - ninja
     - cmake
   files:
     - test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,11 @@ package:
 source:
   url: https://github.com/assimp/assimp/archive/v{{ version }}.tar.gz
   sha1: {{ sha256 }}
+  patches:
+    - fix_rt_link.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
 

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -3,12 +3,12 @@ setlocal EnableDelayedExpansion
 cd test
 
 :: Compile example that links assimp
-cmake -DCMAKE_BUILD_TYPE=Release .
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release .
 if errorlevel 1 exit 1
 
 cmake --build . --config Release
 if errorlevel 1 exit 1
 
 :: Run example
-.\Release\assimp_main.exe
+.\assimp_main.exe
 if errorlevel 1 exit 1

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -4,7 +4,7 @@
 cd test
 
 # Compile example that links assimp
-cmake -DCMAKE_BUILD_TYPE=Release .
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release .
 
 cmake --build . --config Release
 

--- a/recipe/test/CMakeLists.txt
+++ b/recipe/test/CMakeLists.txt
@@ -11,9 +11,9 @@ target_link_libraries(assimp_main PRIVATE assimp::assimp)
 # Detect regression in assimp::assimp link of librt
 get_property(assimp_INTERFACE_LINK_LIBRARIES TARGET assimp::assimp PROPERTY INTERFACE_LINK_LIBRARIES)
 
-string(FIND ${assimp_INTERFACE_LINK_LIBRARIES} "/sysroot/usr/lib/librt" librt_problem_detected)
+string(REGEX MATCH "/sysroot/usr/lib/librt" librt_problem_detected ${assimp_INTERFACE_LINK_LIBRARIES})
 
-message(STATUS "assimp_INTERFACE_LINK_LIBRARIES: ${assimp_INTERFACE_LINK_LIBRARIES}")
-if(NOT ${librt_problem_detected} STREQUAL "-1")
+if(NOT ${librt_problem_detected} STREQUAL "")
   message(FATAL_ERROR "librt linking problem detected")
 endif()
+

--- a/recipe/test/CMakeLists.txt
+++ b/recipe/test/CMakeLists.txt
@@ -7,3 +7,12 @@ find_package(assimp REQUIRED)
 add_executable(assimp_main assimp_main.cpp)
 
 target_link_libraries(assimp_main PRIVATE assimp::assimp)
+
+# Detect regression in assimp::assimp link of librt
+get_property(assimp_INTERFACE_LINK_LIBRARIES TARGET assimp::assimp PROPERTY INTERFACE_LINK_LIBRARIES)
+
+string(FIND ${assimp_INTERFACE_LINK_LIBRARIES} "/sysroot/usr/lib/librt" librt_problem_detected)
+
+if(librt_problem_detected)
+  message(FATAL_ERROR "librt linking problem detected")
+endif()

--- a/recipe/test/CMakeLists.txt
+++ b/recipe/test/CMakeLists.txt
@@ -13,6 +13,7 @@ get_property(assimp_INTERFACE_LINK_LIBRARIES TARGET assimp::assimp PROPERTY INTE
 
 string(FIND ${assimp_INTERFACE_LINK_LIBRARIES} "/sysroot/usr/lib/librt" librt_problem_detected)
 
-if(librt_problem_detected)
+message(STATUS "assimp_INTERFACE_LINK_LIBRARIES: ${assimp_INTERFACE_LINK_LIBRARIES}")
+if(NOT ${librt_problem_detected} STREQUAL "-1")
   message(FATAL_ERROR "librt linking problem detected")
 endif()


### PR DESCRIPTION
Let's see if with these change we are able to detected the regression in https://github.com/conda-forge/assimp-feedstock/issues/14 .

Fix https://github.com/conda-forge/assimp-feedstock/issues/32 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
