### PR TITLE
Fix license SPDX identifier

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jcarpent @lesteve @traversaro @wolfv
+* @jcarpent @traversaro @wolfv

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/assimp-feedstoc
 
 Home: https://assimp.org/
 
-Package license: Modified BSD
+Package license: BSD-3-Clause
 
 Summary: A library to import and export various 3d-model-formats including scene-post-processing to generate missing render data.
 
@@ -198,7 +198,6 @@ Feedstock Maintainers
 =====================
 
 * [@jcarpent](https://github.com/jcarpent/)
-* [@lesteve](https://github.com/lesteve/)
 * [@traversaro](https://github.com/traversaro/)
 * [@wolfv](https://github.com/wolfv/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha1: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x.x') }}
 
@@ -46,7 +46,7 @@ test:
 about:
   home: https://assimp.org/
   summary: A library to import and export various 3d-model-formats including scene-post-processing to generate missing render data.
-  license: Modified BSD
+  license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
 


### PR DESCRIPTION
Not sure if this is related to https://github.com/conda-forge/assimp-feedstock/issues/52, but at least it should make the linter happy.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
