### PR TITLE
 Relax run_exports compatibility

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 6627.patch
 
 build:
-  number: 
+  number: 1
   run_exports:
     # On each new release of assimp, always check for possible ABI breaks and the value of ASSIMP_SOVERSION in CMake,
     # to ensure that the assumption of ABI compat for major version is respected

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,11 @@ source:
     - 6627.patch
 
 build:
-  number: 0
+  number: 
   run_exports:
-    - {{ pin_subpackage(name, max_pin='x.x.x') }}
+    # On each new release of assimp, always check for possible ABI breaks and the value of ASSIMP_SOVERSION in CMake,
+    # to ensure that the assumption of ABI compat for major version is respected
+    - {{ pin_subpackage(name, max_pin='x') }}
 
 requirements:
   build:


### PR DESCRIPTION
See https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/8172#issuecomment-4362013960 . All version of assimp >= 6.0.2 are ABI compatible, so it does not make sense to keep a strick abi compat in run_exports.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
